### PR TITLE
Task 2.1 -- Issues column

### DIFF
--- a/app/controllers/my_news_items_controller.rb
+++ b/app/controllers/my_news_items_controller.rb
@@ -63,6 +63,6 @@ class MyNewsItemsController < SessionController
 
   # Only allow a list of trusted parameters through.
   def news_item_params
-    params.require(:news_item).permit(:news, :title, :description, :link, :representative_id)
+    params.require(:news_item).permit(:news, :title, :description, :link, :representative_id, :issue)
   end
 end

--- a/app/controllers/my_news_items_controller.rb
+++ b/app/controllers/my_news_items_controller.rb
@@ -3,6 +3,7 @@
 class MyNewsItemsController < SessionController
   before_action :set_representative
   before_action :set_representatives_list
+  before_action :set_issues_list
   before_action :set_news_item, only: %i[edit update destroy]
 
   def new
@@ -50,6 +51,14 @@ class MyNewsItemsController < SessionController
 
   def set_news_item
     @news_item = NewsItem.find(params[:id])
+  end
+
+  def set_issues_list
+    @issues_list = ["Free Speech", "Immigration", "Terrorism", "Social Security and
+    Medicare", "Abortion", "Student Loans", "Gun Control", "Unemployment",
+    "Climate Change", "Homelessness", "Racism", "Tax Reform", "Net
+    Neutrality", "Religious Freedom", "Border Security", "Minimum Wage",
+    "Equal Pay"]
   end
 
   # Only allow a list of trusted parameters through.

--- a/app/controllers/my_news_items_controller.rb
+++ b/app/controllers/my_news_items_controller.rb
@@ -54,11 +54,11 @@ class MyNewsItemsController < SessionController
   end
 
   def set_issues_list
-    @issues_list = ["Free Speech", "Immigration", "Terrorism", "Social Security and
-    Medicare", "Abortion", "Student Loans", "Gun Control", "Unemployment",
-    "Climate Change", "Homelessness", "Racism", "Tax Reform", "Net
-    Neutrality", "Religious Freedom", "Border Security", "Minimum Wage",
-    "Equal Pay"]
+    @issues_list = ['Free Speech', 'Immigration', 'Terrorism', "Social Security and
+    Medicare", 'Abortion', 'Student Loans', 'Gun Control', 'Unemployment',
+                    'Climate Change', 'Homelessness', 'Racism', 'Tax Reform', "Net
+    Neutrality", 'Religious Freedom', 'Border Security', 'Minimum Wage',
+                    'Equal Pay']
   end
 
   # Only allow a list of trusted parameters through.

--- a/app/views/my_news_items/_form.html.haml
+++ b/app/views/my_news_items/_form.html.haml
@@ -28,5 +28,11 @@
         .col-sm-10
             = select :news_item, :representative_id, representatives_list, { include_blank: true },
             class: 'form-control'
+    .form-group.row
+        .col-sm-2
+            = label :news_item, :issue, class: 'col-form-label'
+        .col-sm-10
+            = select :news_item, :issue, @issues_list, { include_blank: true },
+            class: 'form-control'
     .actions
         = f.submit 'Save', class: 'btn btn-primary'

--- a/app/views/my_news_items/_form.html.haml
+++ b/app/views/my_news_items/_form.html.haml
@@ -32,7 +32,7 @@
         .col-sm-2
             = label :news_item, :issue, class: 'col-form-label'
         .col-sm-10
-            = select :news_item, :issue, @issues_list, { include_blank: true },
+            = select :news_item, :issue, issues_list, { include_blank: true },
             class: 'form-control'
     .actions
         = f.submit 'Save', class: 'btn btn-primary'

--- a/app/views/my_news_items/edit.html.haml
+++ b/app/views/my_news_items/edit.html.haml
@@ -7,6 +7,7 @@
          form_url: representative_edit_my_news_item_path(@representative, @news_item),
          form_method: :put,
          representatives_list: @representatives_list
+         issues_list: @issues_list
 
     .col-12.col-md-6.offset-md-3.col-xl-4.offset-xl-4
         .clearfix.mt-3

--- a/app/views/my_news_items/edit.html.haml
+++ b/app/views/my_news_items/edit.html.haml
@@ -6,7 +6,7 @@
         = render 'form', news_item: @news_item,
          form_url: representative_edit_my_news_item_path(@representative, @news_item),
          form_method: :put,
-         representatives_list: @representatives_list
+         representatives_list: @representatives_list,
          issues_list: @issues_list
 
     .col-12.col-md-6.offset-md-3.col-xl-4.offset-xl-4

--- a/app/views/my_news_items/new.html.haml
+++ b/app/views/my_news_items/new.html.haml
@@ -7,6 +7,7 @@
         form_url: representative_new_my_news_item_path(@representative),
         form_method: :post,
         representatives_list: @representatives_list
+        issues_list: @issues_list
     .col-12.col-md-6.offset-md-3.col-xl-4.offset-xl-4
         .clearfix.mt-3
             .float-right

--- a/app/views/my_news_items/new.html.haml
+++ b/app/views/my_news_items/new.html.haml
@@ -6,7 +6,7 @@
         = render 'form', news_item: @news_item,
         form_url: representative_new_my_news_item_path(@representative),
         form_method: :post,
-        representatives_list: @representatives_list
+        representatives_list: @representatives_list,
         issues_list: @issues_list
     .col-12.col-md-6.offset-md-3.col-xl-4.offset-xl-4
         .clearfix.mt-3

--- a/app/views/my_news_items/new.html.haml
+++ b/app/views/my_news_items/new.html.haml
@@ -1,6 +1,6 @@
 .row.mt-2
     .col-12.col-md-6.offset-md-3.col-xl-4.offset-xl-4
-        %h1.text-center Edit news article
+        %h1.text-center New news article
 
     .col-12.col-md-6.offset-md-3.col-xl-4.offset-xl-4
         = render 'form', news_item: @news_item,

--- a/app/views/news_items/index.html.haml
+++ b/app/views/news_items/index.html.haml
@@ -18,6 +18,7 @@
                             %th #
                             %th Name
                             %th Description
+                            %th Issue
                             %th Posted
                             %th{ colspan: 3 } Links
                     %tbody
@@ -30,6 +31,7 @@
                                         &nbsp;
                                         %i.fas.fa-external-link-alt
                                 %td= item.description
+                                %td= item.issue
                                 %td
                                     %time.timeago{ datetime: item.created_at.iso8601 }
                                 %td

--- a/app/views/news_items/show.html.haml
+++ b/app/views/news_items/show.html.haml
@@ -25,6 +25,10 @@
                     %dt.col-sm-3.text-md-right Last Updated:
                     %dt.col-sm-9
                         %time.timeago{ datetime: @news_item.updated_at.iso8601 }
+                %dl.row
+                    %dt.col-sm-3.text-md-right Issue:
+                    %dt.col-sm-9
+                        = @news_item.issue
     .col-12.col-md-6.offset-md-3.col-xl-4.offset-xl-4
         .clearfix
             .float-right

--- a/db/migrate/20231130025200_add_issues_to_news_articles.rb
+++ b/db/migrate/20231130025200_add_issues_to_news_articles.rb
@@ -1,5 +1,5 @@
 class AddIssuesToNewsArticles < ActiveRecord::Migration[5.2]
   def change
-    add_column :news_articles, :issue, :string
+    add_column :news_items, :issue, :string
   end
 end

--- a/db/migrate/20231130025200_add_issues_to_news_articles.rb
+++ b/db/migrate/20231130025200_add_issues_to_news_articles.rb
@@ -1,0 +1,5 @@
+class AddIssuesToNewsArticles < ActiveRecord::Migration[5.2]
+  def change
+    add_column :news_articles, :issue, :string
+  end
+end

--- a/db/migrate/20231130032152_add_issues_to_news_items.rb
+++ b/db/migrate/20231130032152_add_issues_to_news_items.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddIssuesToNewsItems < ActiveRecord::Migration[5.2]
   def change
     add_column :news_items, :issue, :string

--- a/db/migrate/20231130032152_add_issues_to_news_items.rb
+++ b/db/migrate/20231130032152_add_issues_to_news_items.rb
@@ -1,4 +1,4 @@
-class AddIssuesToNewsArticles < ActiveRecord::Migration[5.2]
+class AddIssuesToNewsItems < ActiveRecord::Migration[5.2]
   def change
     add_column :news_items, :issue, :string
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_11_30_025200) do
+ActiveRecord::Schema.define(version: 2023_11_30_032152) do
 
   create_table "counties", force: :cascade do |t|
     t.string "name", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_11_27_001613) do
+ActiveRecord::Schema.define(version: 2023_11_30_025200) do
 
   create_table "counties", force: :cascade do |t|
     t.string "name", null: false
@@ -40,6 +40,7 @@ ActiveRecord::Schema.define(version: 2023_11_27_001613) do
     t.integer "representative_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "issue"
     t.index ["representative_id"], name: "index_news_items_on_representative_id"
   end
 

--- a/features/news_items.feature
+++ b/features/news_items.feature
@@ -28,13 +28,12 @@ Background: representatives have been added to database
 
 
   Scenario: Create and edit a news item
-    Given I am authenticated
-    And I visit the create news item page
-    And I fill in "title" with "test"
-    And I fill in "link" with "https://google.com"
-    And I fill in "description" with "test description"
-    And I fill in "representative" with "Gavin Newsom"
-    And I fill in "issue" with "Terrorism"
+    Given I visit the create news item page
+    And I fill in "news_item_title" with "test"
+    And I fill in "news_item_link" with "https://google.com"
+    And I fill in "news_item_description" with "test description"
+    And I select "Gavin Newsom" from "news_item_representative_id"
+    And I select "Terrorism" from "news_item_issue"
     And I press "commit"
     Then I should see "test"
     And I should see "https://google.com"
@@ -42,8 +41,8 @@ Background: representatives have been added to database
     And I should see "Gavin Newsom"
     And I should see "Terrorism"
 
-    When I press "Edit"
-    And I fill in "issue" with "Homelessness"
+    When I follow "Edit"
+    And I select "Homelessness" from "news_item_issue"
     And I press "commit"
     Then I should see "Homelessness"
     And I should not see "Terrorism"

--- a/features/news_items.feature
+++ b/features/news_items.feature
@@ -28,12 +28,27 @@ Background: representatives have been added to database
 
 
   Scenario: Create and edit a news item
-    Given I am on the create news item page
+    Given I am authenticated
+    And I visit the create news item page
     And I fill in "title" with "test"
     And I fill in "link" with "https://google.com"
     And I fill in "description" with "test description"
     And I fill in "representative" with "Gavin Newsom"
     And I fill in "issue" with "Terrorism"
+    And I press "commit"
+    Then I should see "test"
+    And I should see "https://google.com"
+    And I should see "test description"
+    And I should see "Gavin Newsom"
+    And I should see "Terrorism"
+
+    When I press "Edit"
+    And I fill in "issue" with "Homelessness"
+    And I press "commit"
+    Then I should see "Homelessness"
+    And I should not see "Terrorism"
+    
+
 
 
   

--- a/features/news_items.feature
+++ b/features/news_items.feature
@@ -25,4 +25,7 @@ Background: representatives have been added to database
     And I press "commit"
     And I click on news articles for Gavin Newsom
     Then I click on add news article
+
+  Scenario: Create and edit a news item
+    Given I am on the create news item page
   

--- a/features/news_items.feature
+++ b/features/news_items.feature
@@ -26,6 +26,14 @@ Background: representatives have been added to database
     And I click on news articles for Gavin Newsom
     Then I click on add news article
 
+
   Scenario: Create and edit a news item
     Given I am on the create news item page
+    And I fill in "title" with "test"
+    And I fill in "link" with "https://google.com"
+    And I fill in "description" with "test description"
+    And I fill in "representative" with "Gavin Newsom"
+    And I fill in "issue" with "Terrorism"
+
+
   

--- a/features/step_definitions/news_items_steps.rb
+++ b/features/step_definitions/news_items_steps.rb
@@ -9,7 +9,7 @@ When /I click on add news article/ do
 end
 
 When /I visit the create news item page/ do
-  visit path_to("the create news item page")
+  visit path_to('the create news item page')
 end
 
 When /I am authenticated/ do

--- a/features/step_definitions/news_items_steps.rb
+++ b/features/step_definitions/news_items_steps.rb
@@ -9,9 +9,6 @@ When /I click on add news article/ do
 end
 
 When /I visit the create news item page/ do
+  allow_any_instance_of(MyNewsItemsController).to receive(:require_login!).and_return(true)
   visit path_to('the create news item page')
-end
-
-When /I am authenticated/ do
-  Rails.application.env_config['omniauth.auth'] = OmniAuth.config.mock_auth[:google_oauth2]
 end

--- a/features/step_definitions/news_items_steps.rb
+++ b/features/step_definitions/news_items_steps.rb
@@ -7,3 +7,11 @@ end
 When /I click on add news article/ do
   find('a.btn-primary').click
 end
+
+When /I visit the create news item page/ do
+  visit path_to("the create news item page")
+end
+
+When /I am authenticated/ do
+  Rails.application.env_config['omniauth.auth'] = OmniAuth.config.mock_auth[:google_oauth2]
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -71,3 +71,5 @@ end
 # The :transaction strategy is faster, but might give you threading problems.
 # See https://github.com/cucumber/cucumber-rails/blob/master/features/choose_javascript_database_strategy.feature
 Cucumber::Rails::Database.javascript_strategy = :truncation
+
+require 'cucumber/rspec/doubles'

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -23,7 +23,7 @@ module NavigationHelpers
     #     user_profile_path(User.find_by_login($1))
 
     when /^the create news item page$/
-      '/representatives/1/representatives/1/my_news_item/new'
+      representative_new_my_news_item_path(representative_id: 1)
 
     else
       begin

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -22,6 +22,9 @@ module NavigationHelpers
     #   when /^(.*)'s profile page$/i
     #     user_profile_path(User.find_by_login($1))
 
+    when /^the create news item page$/
+      '/representatives/1/representatives/1/my_news_item/new'
+
     else
       begin
         page_name =~ /^the (.*) page$/


### PR DESCRIPTION
#21 
Adds infrastructure for an `issue` attribute for `NewsItem` objects.
On the frontend, adds dropdown to both "New" and "Edit" pages for news items, and shows the issue on the item's "Show" page.

When pulling these changes run `rails db:migrate` to apply the new migration.